### PR TITLE
Add OpenAI-powered chatbot interface

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,10 +13,12 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
-    "sqlite3": "^5.1.6"
+    "sqlite3": "^5.1.6",
+    "openai": "^4.0.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
 import { AppService } from './app.service';
 
 @Controller('api')
@@ -8,5 +8,10 @@ export class AppController {
   @Get('info')
   getInfo() {
     return this.appService.getCompany();
+  }
+
+  @Post('chat')
+  chat(@Body('messages') messages: { role: string; content: string }[]) {
+    return this.appService.chat(messages);
   }
 }

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -2,9 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Company } from './company.entity';
+import OpenAI from 'openai';
 
 @Injectable()
 export class AppService {
+  private openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
   constructor(
     @InjectRepository(Company)
     private companyRepo: Repository<Company>,
@@ -21,5 +24,19 @@ export class AppService {
       await this.companyRepo.save(company);
     }
     return company;
+  }
+
+  async chat(messages: { role: string; content: string }[]) {
+    const completion = await this.openai.chat.completions.create({
+      model: 'gpt-5',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are an expert assistant who provides helpful travel tips.',
+        },
+        ...messages,
+      ],
+    });
+    return { reply: completion.choices[0].message.content };
   }
 }

--- a/backend/src/company.entity.ts
+++ b/backend/src/company.entity.ts
@@ -3,11 +3,11 @@ import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
 @Entity()
 export class Company {
   @PrimaryGeneratedColumn()
-  id: number;
+  id!: number;
 
   @Column()
-  name: string;
+  name!: string;
 
   @Column()
-  tagline: string;
+  tagline!: string;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
   await app.listen(3000);
   console.log('Backend running on http://localhost:3000');
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,13 @@ import './app.css';
 
 export default function App() {
   const [company, setCompany] = useState(null);
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      content: 'Hi! I am your travel assistant. Ask me for tips on your next trip.',
+    },
+  ]);
+  const [input, setInput] = useState('');
 
   useEffect(() => {
     fetch('http://localhost:3000/api/info')
@@ -12,6 +19,28 @@ export default function App() {
         setCompany({ name: 'Automaite', tagline: 'AI-driven automation' })
       );
   }, []);
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const newMessages = [...messages, { role: 'user', content: input }];
+    setMessages(newMessages);
+    setInput('');
+    try {
+      const res = await fetch('http://localhost:3000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages }),
+      });
+      const data = await res.json();
+      setMessages([ ...newMessages, { role: 'assistant', content: data.reply } ]);
+    } catch (err) {
+      setMessages([ ...newMessages, { role: 'assistant', content: 'Error contacting AI service.' } ]);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') sendMessage();
+  };
 
   return (
     <div className="app">
@@ -26,6 +55,23 @@ export default function App() {
           <p>{company.tagline}</p>
         </section>
       )}
+
+      <section className="chat">
+        {messages.map((m, idx) => (
+          <div key={idx} className={`message ${m.role}`}>
+            {m.content}
+          </div>
+        ))}
+        <div className="input-area">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask for travel tips..."
+          />
+          <button onClick={sendMessage}>Send</button>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -29,3 +29,52 @@ p {
 .info {
   margin-top: 2rem;
 }
+
+.chat {
+  margin: 2rem auto;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  max-width: 80%;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: #6c43f3;
+  color: #fff;
+}
+
+.message.assistant {
+  align-self: flex-start;
+  background: #1e1e1e;
+}
+
+.input-area {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.input-area input {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #0a0a0a;
+  color: #e0e0e0;
+}
+
+.input-area button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #00d4ff;
+  color: #0a0a0a;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- Use `gpt-5` model with a system prompt that provides travel tips
- Initialize chat UI with a travel assistant greeting and travel-tip placeholder

## Testing
- `npm test` (backend) *(fails: No tests)*
- `npm run build` (backend) *(fails: Cannot find module '@nestjs/typeorm'; 'openai')*
- `npm test` (frontend) *(fails: No tests)*
- `npm run build` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68a6939babbc8326ac4d0db375f6b7dc